### PR TITLE
chore: Add envoyproxy/protoc-gen-validate to GONOPROXY and GONOSUMDB

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -124,8 +124,8 @@ jobs:
           RENOVATE_DOCKER_DOCKER_IO_PASSWORD: ${{ env.RENOVATE_DOCKER_DOCKER_IO_PASSWORD || secrets.DOCKER_HUB_PAT }}
           RENOVATE_TERRAFORM__MODULE_APP_SPACELIFT_IO_TOKEN: ${{ env.RENOVATE_TERRAFORM__MODULE_APP_SPACELIFT_IO_TOKEN || secrets.SPACELIFT_READ_TOKEN }}
           RENOVATE_TERRAFORM__MODULE_SPACELIFT_IO_TOKEN: ${{ env.RENOVATE_TERRAFORM__MODULE_SPACELIFT_IO_TOKEN || secrets.SPACELIFT_READ_TOKEN }}
-          GONOPROXY: ${{ env.GONOPROXY || 'github.com/coopnorge' }}
-          GONOSUMDB: ${{ env.GONOSUMDB || 'github.com/coopnorge' }}
+          GONOPROXY: ${{ env.GONOPROXY || 'github.com/coopnorge,github:com/envoyproxy/protoc-gen-validate' }}
+          GONOSUMDB: ${{ env.GONOSUMDB || 'github.com/coopnorge,github:com/envoyproxy/protoc-gen-validate' }}
           GOPRIVATE: ${{ env.GOPRIVATE || 'github.com/coopnorge' }}
         with:
           configurationFile: ${{ inputs.config-file }}


### PR DESCRIPTION
Getting the following for this library as renovate tries to get version info from proxy.
>DEBUG: GET proxy.golang.org/github.com/envoyproxy/protoc-gen-validate/@v/v0.10.0-SNAPSHOT.7.info = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=551)

It is used in several places so it makes sense to have it configured here.
