### PR TITLE
fix: Use custom image correctly

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -197,6 +197,6 @@ jobs:
         with:
           configurationFile: ${{ inputs.config-file }}
           token: ${{ steps.get_github_token.outputs.token }}
-          renovate-image: ${{ steps.check-custom-image.outputs.custom-image == 'true' && 'ocreg.invalid/renovate' || 'ghcr.io/renovatebot/renovate' }}
+          renovate-image: ${{ steps.check-custom-image.outputs.custom-image != 'false' && 'ocreg.invalid/renovate' || 'ghcr.io/renovatebot/renovate' }}
           renovate-version: latest
           env-regex: ${{ steps.config-env.outputs.env-regex }}


### PR DESCRIPTION
custom-image output was change from true/false to image-name/false in https://github.com/coopnorge/github-workflow-renovate/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Amerged