### PR TITLE
chore: Add package rule for echo

### DIFF
--- a/go.json5
+++ b/go.json5
@@ -22,8 +22,8 @@
             ]
         },
         {
-            "groupName": "echo packages",
-            "groupSlug": "echo",
+            "groupName": "echo go packages",
+            "groupSlug": "echo go",
             "matchDatasources": [
                 "go"
             ],

--- a/go.json5
+++ b/go.json5
@@ -22,7 +22,7 @@
             ]
         },
         {
-            "groupName": "echo-go packages",
+            "groupName": "echo go packages",
             "groupSlug": "echo-go",
             "matchDatasources": [
                 "go"

--- a/go.json5
+++ b/go.json5
@@ -22,8 +22,8 @@
             ]
         },
         {
-            "groupName": "echo go packages",
-            "groupSlug": "echo go",
+            "groupName": "echo-go packages",
+            "groupSlug": "echo-go",
             "matchDatasources": [
                 "go"
             ],

--- a/go.json5
+++ b/go.json5
@@ -28,7 +28,7 @@
                 "go"
             ],
             "matchPackageNames": [
-                "github.com/labstack/echo/**",
+                "github.com/labstack/echo",
                 "github.com/labstack/echo-*"
             ]
         }

--- a/go.json5
+++ b/go.json5
@@ -20,6 +20,17 @@
             "matchPackageNames": [
                 "github.com/DataDog/dd-trace-go/**"
             ]
+        },
+        {
+            "groupName": "echo packages",
+            "groupSlug": "echo",
+            "matchDatasources": [
+                "go"
+            ],
+            "matchPackageNames": [
+                "github.com/labstack/echo/**",
+                "github.com/labstack/echo-jwt/**"
+            ]
         }
     ]
 }

--- a/go.json5
+++ b/go.json5
@@ -29,7 +29,7 @@
             ],
             "matchPackageNames": [
                 "github.com/labstack/echo/**",
-                "github.com/labstack/echo-jwt/**"
+                "github.com/labstack/echo-*"
             ]
         }
     ]


### PR DESCRIPTION
We have two renovate PRs in our repo that separately bump `echo` and `echo-jwt` to v5. However `echo-jwt` is dependent on `echo` being v5, and vice-versa. So these packages can't really be bumped separately.

See:
https://github.com/coopnorge/customer-order-management/pull/2961
https://github.com/coopnorge/customer-order-management/pull/2960