### PR TITLE
chore: Don't limit number of open PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,6 +14,7 @@
         "{{depName}}"
     ],
     "prHourlyLimit": 5,
+    "prConcurrentLimit": 0,
     "automerge": true,
     "automergeStrategy": "squash",
     "minimumReleaseAge": "14 days",


### PR DESCRIPTION
The default number of open PRs per repo is 10. This may lead to missed updates.
