### PR TITLE
fix: Use latest renovate version if using custom image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
             "customType": "regex",
             "managerFilePatterns": ["/^\\.github/workflows/renovate\\.yaml$/"],
             "matchStrings": [
-                "renovate-version:\\s*(?<currentValue>[0-9.]+)"
+                "RENOVATE_VERSION:\\s*(?<currentValue>[0-9.]+)"
             ],
             "datasourceTemplate": "github-releases",
             "depNameTemplate": "renovatebot/renovate",

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -42,6 +42,9 @@ on:
           Defaults to `vars.PALLET_SERVICE_ACCOUNT`.
     secrets: {}
 
+env:
+  RENOVATE_VERSION: 43.182.2
+
 jobs:
   renovate:
     permissions:
@@ -84,6 +87,17 @@ jobs:
         name: Build custom renovate image
         run: |
           docker buildx build -f .temp/github-workflow-renovate/images/${{ steps.choose-custom-image.outputs.custom-image }}.Dockerfile -t ocreg.invalid/renovate:latest --load .
+
+      - name: Determine renovate version to use
+        id: renovate-version
+        env:
+          CUSTOM_IMAGE: ${{ steps.choose-custom-image.outputs.custom-image }}
+        run: |
+          if [ "$CUSTOM_IMAGE" != "false" ]; then
+            echo "renovate-version=latest" >> $GITHUB_OUTPUT
+          else
+            echo "renovate-version=$RENOVATE_VERSION" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get GitHub token
         id: get_github_token
@@ -198,5 +212,5 @@ jobs:
           configurationFile: ${{ inputs.config-file }}
           token: ${{ steps.get_github_token.outputs.token }}
           renovate-image: ${{ steps.choose-custom-image.outputs.custom-image != 'false' && 'ocreg.invalid/renovate' || 'ghcr.io/renovatebot/renovate' }}
-          renovate-version: 43.182.2
+          renovate-version: ${{ steps.renovate-version.outputs.renovate-version }}
           env-regex: ${{ steps.config-env.outputs.env-regex }}


### PR DESCRIPTION
Renovate runs in terraform modules are broken: https://github.com/coopnorge/terraform-spacelift-stack/actions/runs/26025444842/job/76497461048

I am assuming it is because if using custom image, the version needs to be latest.