### PR TITLE
feat: Add terraform preset; group google providers

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,8 @@
         "github>coopnorge/github-workflow-renovate:docker.json5",
         "github>coopnorge/github-workflow-renovate:helm-values.json5",
         "github>coopnorge/github-workflow-renovate:helm.json5",
-        "github>coopnorge/github-workflow-renovate:python.json5"
+        "github>coopnorge/github-workflow-renovate:python.json5",
+        "github>coopnorge/github-workflow-renovate:terraform.json5"
     ],
     "labels": [
         "dependencies",

--- a/terraform.json5
+++ b/terraform.json5
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "packageRules": [
+        {
+            "description": "Group google and google-beta terraform provider updates together",
+            "groupName": "terraform google providers",
+            "groupSlug": "terraform-google-providers",
+            "matchManagers": [
+                "terraform"
+            ],
+            "matchPackageNames": [
+                "google",
+                "google-beta"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Keeps the `google` and `google-beta` providers in sync.

Fixes https://github.com/coopnorge/github-workflow-renovate/issues/153