### PR TITLE
ci: Validate configuration

### DIFF
--- a/.github/path-filters.yaml
+++ b/.github/path-filters.yaml
@@ -11,3 +11,8 @@ techdocs:
   - docs/**
   - devtools/techdocs.*
   - .vale/**
+renovate-config:
+  - 'default.json'
+  - '*.json5'
+  - '.github/renovate.json5'
+  - '.github/workflows/validate-renovate-config.yaml'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,9 +6,10 @@
     "customManagers": [
         {
             "customType": "regex",
-            "managerFilePatterns": ["/^\\.github/workflows/renovate\\.yaml$/"],
+            "managerFilePatterns": ["/^\\.github/workflows/.*renovate.*\\.yaml$/"],
             "matchStrings": [
-                "RENOVATE_VERSION:\\s*(?<currentValue>[0-9.]+)"
+                "RENOVATE_VERSION:\\s*(?<currentValue>[0-9.]+)",
+                "ghcr\\.io/renovatebot/renovate:(?<currentValue>[0-9.]+)"
             ],
             "datasourceTemplate": "github-releases",
             "depNameTemplate": "renovatebot/renovate",

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       run-kubernetes-ci: ${{ ( steps.changes.outputs.kubernetes == 'true' || steps.changes.outputs.workflows == 'true' ) && github.event_name == 'pull_request' }}
       validate-policy-bot-config: ${{ steps.changes.outputs.policy-bot == 'true' && github.event_name == 'pull_request' }}
+      validate-renovate-config: ${{ steps.changes.outputs.renovate-config == 'true' && github.event_name == 'pull_request' }}
       techdocs: >-
         ${{ steps.changes.outputs.techdocs == 'true' || steps.changes.outputs.workflows == 'true' }}
     steps:
@@ -55,11 +56,26 @@ jobs:
     secrets:
       policy-bot-server-url: ${{ secrets.POLICY_BOT_BASE_URL }}
 
+  validate-renovate-config:
+    name: "Validate Renovate config"
+    needs: setup
+    if: needs.setup.outputs.validate-renovate-config == 'true'
+    uses: ./.github/workflows/validate-renovate-config.yaml
+    permissions:
+      contents: read
+      pull-requests: read
+    with:
+      config-paths: |
+        default.json
+        *.json5
+        .github/renovate.json5
+
   validate-ci-results:
     needs:
       - kubernetes-ci
       - policy-bot
       - techdocs
+      - validate-renovate-config
     if: failure() || cancelled()
     runs-on: ubuntu-slim
     permissions: {}

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -1,0 +1,71 @@
+name: Validate Renovate config
+on:
+  workflow_call:
+    inputs:
+      config-paths:
+        type: string
+        required: false
+        description: |
+          Newline-separated list of Renovate config file paths to watch and validate.
+          Defaults to common consumer repo locations.
+        default: |
+          .github/renovate.json5
+          renovate.json5
+          renovate.json
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      renovate-config: ${{ steps.changes.outputs.renovate-config }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Resolve trigger paths
+        id: resolve-paths
+        env:
+          CONFIG_PATHS: ${{ inputs.config-paths }}
+        run: |
+          {
+            echo "paths<<EOF"
+            echo "renovate-config:"
+            while IFS= read -r path; do
+              [ -n "$path" ] && echo "  - '$path'"
+            done <<< "$CONFIG_PATHS"
+            echo "  - '.github/workflows/validate-renovate-config.yaml'"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        id: changes
+        with:
+          filters: ${{ steps.resolve-paths.outputs.paths }}
+
+  validate-renovate-config:
+    name: Validate Renovate config
+    needs: setup
+    if: needs.setup.outputs.renovate-config == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate Renovate config
+        env:
+          CONFIG_PATHS: ${{ inputs.config-paths }}
+        run: |
+          FILES=""
+          while IFS= read -r path; do
+            [ -n "$path" ] && FILES="$FILES $path"
+          done <<< "$CONFIG_PATHS"
+          # Expand globs and filter to existing files
+          EXISTING_FILES=""
+          for f in $FILES; do
+            [ -f "$f" ] && EXISTING_FILES="$EXISTING_FILES $f"
+          done
+          docker run --rm \
+            -v "${{ github.workspace }}:/usr/src/app" \
+            ghcr.io/renovatebot/renovate:43.191.2 \
+            renovate-config-validator $EXISTING_FILES


### PR DESCRIPTION
Add a workflow that validates the renovate configuration.

Uses a paths filter that by default is configured for a sensible place for a renovate config file in the consumer repos. To validate the config in _this_ repository, we override the default by calling it with the filter input from cicd.yaml.

As a result, this should work to validate the configuration both here and in consumer repos.

Instead of using an npx command like in the example in the documentation, we will use the same renovate as we use for our main renovate command.

---

Demoed in #158
Documented in #159
See #31