### PR TITLE
chore: Add renovate config for GO_VERSION

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,5 +14,15 @@
             "depNameTemplate": "renovatebot/renovate",
             "versioningTemplate": "semver",
         },
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^images/terraform-modules\\.Dockerfile$/"],
+            "matchStrings": [
+                "GO_VERSION\s*=\s*(?<currentValue>[0-9.]+)"
+            ],
+            "datasourceTemplate": "golang-version",
+            "depNameTemplate": "go",
+            "versioningTemplate": "semver"
+        },
     ],
 }


### PR DESCRIPTION
For updating this: https://github.com/coopnorge/github-workflow-renovate/blob/db46a0e0db436de2dabfb6e287e0bbf4b6c5f939/images/terraform-modules.Dockerfile#L6