### PR TITLE
fix: Terraform groupings needs to specify the owner of the provider

### DIFF
--- a/terraform.json5
+++ b/terraform.json5
@@ -9,8 +9,8 @@
                 "terraform"
             ],
             "matchPackageNames": [
-                "google",
-                "google-beta"
+                "hashicorp/google",
+                "hashicorp/google-beta"
             ]
         }
     ]


### PR DESCRIPTION
Example output from a Renovate that did not end up grouping the google/google-beta updates:
```json
{
                 "currentValue": ">= 7.10.0",
                 "depType": "required_provider",
                 "depName": "google-beta",
                 "datasource": "terraform-provider",
                 "packageName": "hashicorp/google-beta",
                 "lockedVersion": "7.32.0",
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "7.33.0",
                     "newValue": ">= 7.10.0",
                     "releaseTimestamp": "2026-05-19T19:30:46.000Z",
                     "newVersionAgeInDays": 21,
                     "newMajor": 7,
                     "newMinor": 33,
                     "newPatch": 0,
                     "updateType": "minor",
                     "isBreaking": false,
                     "isRange": true,
                     "isLockfileUpdate": true,
                     "pendingVersions": ["7.34.0", "7.35.0", "7.36.0"],
                     "libYears": 0.0194546867072552,
                     "branchName": "renovate/google-beta-7.x-lockfile"
                   }
                 ],
                 "versioning": "hashicorp",
                 "warnings": [],
                 "sourceUrl": "https://github.com/hashicorp/terraform-provider-google-beta",
                 "registryUrl": "https://registry.terraform.io/",
                 "homepage": "https://registry.terraform.io/providers/hashicorp/google-beta",
                 "mostRecentTimestamp": "2026-06-09T18:40:12.000Z",
                 "currentVersion": "7.32.0",
                 "currentVersionTimestamp": "2026-05-12T17:05:23.000Z",
                 "currentVersionAgeInDays": 28,
                 "isSingleVersion": true,
                 "fixedVersion": "7.32.0"
               },
```

The important part is the `"packageName": "hashicorp/google-beta",`