### PR TITLE
fix: Set prCreation = not-pending

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,6 +18,8 @@
     "prConcurrentLimit": 0,
     "automerge": true,
     "automergeStrategy": "squash",
+    "prCreation": "not-pending",
+    "prNotPendingHours": 336,
     "minimumReleaseAge": "14 days",
     "rebaseWhen": "conflicted",
     "postUpdateOptions": [


### PR DESCRIPTION
ref: https://docs.renovatebot.com/configuration-options/#prcreation

It seems that the default value for `prCreation` determines when the PR with failing status checks are created. The default value is `immediate` so even when `stability-days` is failing because of `minimumReleaseAge` is not available, the PR is created immediately and then a `stability-days` check added. Setting `prCreation` = `not-pending` seems to stop this behavior. `prNotPendingHours`=`336` should make these PRs to be created after 14 days.
