### PR TITLE
fix: Change `prCreation` back to `immediate` (default) for cases when `minimumReleaseAge` = `0`

### DIFF
--- a/docker.json5
+++ b/docker.json5
@@ -4,6 +4,7 @@
         {
             "description": "No update cooldown for internal coopnorge devtool images",
             "minimumReleaseAge": "0 days",
+            "prCreation": "immediate",
             "matchDatasources": [
                 "docker"
             ],

--- a/go.json5
+++ b/go.json5
@@ -4,6 +4,7 @@
         {
             "description": "No update cooldown for internal coopnorge modules",
             "minimumReleaseAge": "0 days",
+            "prCreation": "immediate",
             "matchDatasources": [
                 "go"
             ],

--- a/helm-values.json5
+++ b/helm-values.json5
@@ -11,6 +11,7 @@
       "rebaseWhen": "behind-base-branch",
       "prHourlyLimit": 0,
       "minimumReleaseAge": "0 days",
+      "prCreation": "immediate",
       "automerge": true,
     },
     {

--- a/helm.json5
+++ b/helm.json5
@@ -8,6 +8,7 @@
       "automerge": true,
       "rebaseWhen": "behind-base-branch",
       "minimumReleaseAge": "0 days",
+      "prCreation": "immediate",
     },
   ],
 }


### PR DESCRIPTION
This was the default before it was changed here: https://github.com/coopnorge/github-workflow-renovate/pull/179
