### PR TITLE
chore: Remove automerge=true from helm-values and helm configs

### DIFF
--- a/helm-values.json5
+++ b/helm-values.json5
@@ -12,7 +12,6 @@
       "prHourlyLimit": 0,
       "minimumReleaseAge": "0 days",
       "prCreation": "immediate",
-      "automerge": true,
     },
     {
       "branchPrefix": "helm/dev/",

--- a/helm.json5
+++ b/helm.json5
@@ -5,7 +5,6 @@
       "matchDatasources": [
         "helm"
       ],
-      "automerge": true,
       "rebaseWhen": "behind-base-branch",
       "minimumReleaseAge": "0 days",
       "prCreation": "immediate",


### PR DESCRIPTION
They are already set to true in default.json and can be misleading.
