### PR TITLE
fix: Correct regex for matchPackageNames in config for terraform

### DIFF
--- a/terraform.json5
+++ b/terraform.json5
@@ -9,7 +9,7 @@
                 "terraform"
             ],
             "matchPackageNames": [
-                "/^spacelift.io\/coopnorge\/.*/",
+                "/^spacelift\\.io/coopnorge/.*/"
             ],
         },
         {


### PR DESCRIPTION
It was the `.` that needed escaping.