### PR TITLE
fix: Install goimports in /usr/local/go/bin/

### DIFF
--- a/images/crossplane-provider.Dockerfile
+++ b/images/crossplane-provider.Dockerfile
@@ -15,8 +15,6 @@ RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.t
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
+RUN GOBIN=/usr/local/go/bin go install golang.org/x/tools/cmd/goimports@v${GOIMPORTS_VERSION}
+
 USER ubuntu
-
-RUN go install golang.org/x/tools/cmd/goimports@v${GOIMPORTS_VERSION}
-
-ENV PATH="/home/ubuntu/go/bin:${PATH}"


### PR DESCRIPTION
It seems renovate image has different GOBIN. Overriding it so that it is where we expect it.

> Command failed: make generate
> Cloning into '/tmp/renovate/repos/github/coopnorge/provider-upjet-spacelift/.work/spacelift-io/spacelift'...
> panic: cannot run goimports for apis folder: bash: line 1: goimports: command not found
> 	: exit status 127
> 
> goroutine 1 [running]:
> github.com/crossplane/upjet/pkg/pipeline.Run(0x166a4efcad80, {0x166a4ef425f0, 0x3d})
> 	/home/ubuntu/go/pkg/mod/github.com/crossplane/upjet@v1.11.0/pkg/pipeline/run.go:206 +0x2247
> main.main()
> 	/tmp/renovate/repos/github/coopnorge/provider-upjet-spacelift/cmd/generator/main.go:26 +0x74
> exit status 2
> apis/generate.go:25: running "go": exit status 1
> generate: open /tmp/renovate/repos/github/coopnorge/provider-upjet-spacelift/apis/context/v1alpha1/zz_generated.deepcopy.go: no such file or directory
> make[1]: *** [build/makelib/golang.mk:154: go.generate] Error 1
> make: *** [build/makelib/common.mk:434: generate] Error 2