### PR TITLE
fix: Correct config so that automerge does not get disabled (docker images)

### DIFF
--- a/docker.json5
+++ b/docker.json5
@@ -21,8 +21,8 @@
             ],
             "matchPackageNames": [
                 "ghcr.io/coopnorge/engineering-docker-images/**"
-            ]
+            ],
+            "commitMessageSuffix": "({{#if newDigest}}{{newDigestShort}}{{else}}{{newValue}}{{/if}})"
         },
-    ]
+    ],
 }
-


### PR DESCRIPTION
> 2026-07-14T11:05:04.6628673Z  DEBUG: findPr(renovate/engineering-docker-images, chore(deps): update coopnorge devtool images, !open)
> 2026-07-14T11:05:04.6630777Z  DEBUG: Found PR #263
> 2026-07-14T11:05:04.6632528Z  DEBUG: Found closed PR with current title
> 2026-07-14T11:05:04.6634473Z  DEBUG: Returning PR from cache
> 2026-07-14T11:05:04.6636291Z  DEBUG: Matching PR #263 was merged previously
> 2026-07-14T11:05:04.6638326Z  DEBUG: Disabling automerge because PR was merged previously
> 