### PR TITLE
chore: Separate packagerules for dotnet packages

### DIFF
--- a/dotnet.json5
+++ b/dotnet.json5
@@ -11,10 +11,16 @@
             "matchPackageNames": [
                 "CoopNorge.**",
             ],
+        },
+        {
+            "description": "Additional registry urls for nuget",
+            "matchDatasources": [
+                "nuget"
+            ],
             "registryUrls": [
                 "https://api.nuget.org/v3/index.json",
                 "https://nuget.pkg.github.com/coopnorge/index.json",
             ],
-        }
+        },
     ],
 }


### PR DESCRIPTION
"No update cooldown" and "additonal registy urls" in the same rule and it doesn't seem to work
