### PR TITLE
feat: Make `GH_REPO_PAT` available for post-upgrade-env-vars

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -238,6 +238,8 @@ jobs:
           # need a PAT for the following because app tokens are not supported as of this writing: https://github.com/orgs/community/discussions/26920
           RENOVATE_NPM_NPM_PKG_GITHUB_COM_TOKEN: ${{ secrets.GH_PACKAGES_READ_PAT }}
           RENOVATE_NUGET_NUGET_PKG_GITHUB_COM_TOKEN: ${{ secrets.GH_PACKAGES_READ_PAT }}
+          # making the PAT available for other use-cases, like downloading release assets for private repos
+          GH_PACKAGES_READ_PAT: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           RENOVATE_ALLOWED_COMMANDS: '[".*"]'
           GONOPROXY: ${{ env.GONOPROXY || 'github.com/coopnorge,github:com/envoyproxy/protoc-gen-validate' }}
           GONOSUMDB: ${{ env.GONOSUMDB || 'github.com/coopnorge,github:com/envoyproxy/protoc-gen-validate' }}


### PR DESCRIPTION
This will be used in post-upgrade-vars when required; eg. https://github.com/coopnorge/homebrew-tap/pull/54

needs https://github.com/coopnorge/github-management/pull/281 to be merged