### PR TITLE
chore: Add UV_INDEX to post-upgrade envs

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -304,6 +304,9 @@ jobs:
             done <<< "$POST_UPGRADE_ENV_VARS"
           fi
           
+          # Add UV_INDEX to post-upgrade
+          JSON_OBJ=$(echo "$JSON_OBJ" | jq -c --arg v "$UV_INDEX" '.UV_INDEX = $v')
+          
           if [[ "$JSON_OBJ" != "{}" ]]; then
             echo "RENOVATE_CUSTOM_ENV_VARIABLES=$JSON_OBJ" >> $GITHUB_ENV
           fi

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -305,7 +305,9 @@ jobs:
           fi
           
           # Add UV_INDEX to post-upgrade
-          JSON_OBJ=$(echo "$JSON_OBJ" | jq -c --arg v "$UV_INDEX" '.UV_INDEX = $v')
+          if [[ -n "$UV_INDEX" ]]; then
+            JSON_OBJ=$(echo "$JSON_OBJ" | jq -c --arg v "$UV_INDEX" '.UV_INDEX = $v')
+          fi
           
           if [[ "$JSON_OBJ" != "{}" ]]; then
             echo "RENOVATE_CUSTOM_ENV_VARIABLES=$JSON_OBJ" >> $GITHUB_ENV

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -191,7 +191,7 @@ jobs:
                     "RENOVATE_${PREFIX}_${REGION}__${SUFFIX}_PKG_DEV_TOKEN=${{ steps.gcp-auth.outputs.access_token }}" \
                     >> "$GITHUB_ENV"
 
-                  if [ "$PREFIX" = "PYPI" ]; then
+                  if [ "$PREFIX" = "PYPI" ] && [ "$REGION" = "EUROPE__NORTH1" ]; then
                     FMT_REGION="${REGION,,}"
                     FMT_REGION="${FMT_REGION//__/-}"
                     UV_INDEX="${UV_INDEX}${UV_INDEX:+ }https://oauth2accesstoken:${{ steps.gcp-auth.outputs.access_token }}@${FMT_REGION}-python.pkg.dev/engineering-production-af50/engineering-pypi/simple/"


### PR DESCRIPTION
Also fix an issue where multiple indexes were added, in which case, uv stops looking when there is an error. ref: https://github.com/coopnorge/github-workflow-renovate/issues/246